### PR TITLE
feat(core): implement transparent plaintext arithmetic and subtraction

### DIFF
--- a/blindbean-example/src/main/java/com/example/entity/UserAccount.java
+++ b/blindbean-example/src/main/java/com/example/entity/UserAccount.java
@@ -1,4 +1,4 @@
-package com.blindbean.entity;
+package com.example.entity;
 
 import com.blindbean.annotations.BlindEntity;
 import com.blindbean.annotations.Homomorphic;

--- a/blindbean-example/src/test/java/com/example/entity/UserAccountTest.java
+++ b/blindbean-example/src/test/java/com/example/entity/UserAccountTest.java
@@ -1,4 +1,4 @@
-package com.blindbean.entity;
+package com.example.entity;
 
 import com.blindbean.context.BlindContext;
 import org.junit.jupiter.api.AfterEach;

--- a/src/main/java/com/blindbean/fhe/FheContext.java
+++ b/src/main/java/com/blindbean/fhe/FheContext.java
@@ -111,6 +111,16 @@ public class FheContext implements AutoCloseable {
         return result;
     }
 
+    /** Homomorphic subtraction of two ciphertexts. */
+    public MemorySegment subtract(MemorySegment a, MemorySegment b) {
+        ensureOpen();
+        MemorySegment result = FheNativeBridge.fhe_subtract(handle, a, b);
+        if (result.equals(MemorySegment.NULL)) {
+            throw new FheException("fhe_subtract returned NULL");
+        }
+        return result;
+    }
+
     /** Homomorphic multiplication of two ciphertexts (auto-relinearized). */
     public MemorySegment multiply(MemorySegment a, MemorySegment b) {
         ensureOpen();

--- a/src/main/java/com/blindbean/fhe/FheNativeBridge.java
+++ b/src/main/java/com/blindbean/fhe/FheNativeBridge.java
@@ -43,6 +43,7 @@ public class FheNativeBridge {
     private static final MethodHandle MH_ENCRYPT_DOUBLE;
     private static final MethodHandle MH_DECRYPT_DOUBLE;
     private static final MethodHandle MH_ADD;
+    private static final MethodHandle MH_SUBTRACT;
     private static final MethodHandle MH_MULTIPLY;
     private static final MethodHandle MH_RELINEARIZE;
     private static final MethodHandle MH_RESCALE;
@@ -80,6 +81,9 @@ public class FheNativeBridge {
                     FunctionDescriptor.of(ValueLayout.JAVA_DOUBLE, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
             MH_ADD = downcall("fhe_add",
+                    FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            MH_SUBTRACT = downcall("fhe_subtract",
                     FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
 
             MH_MULTIPLY = downcall("fhe_multiply",
@@ -175,6 +179,14 @@ public class FheNativeBridge {
             return (MemorySegment) MH_ADD.invokeExact(ctx, a, b);
         } catch (Throwable e) {
             throw new FheException("Failed to call fhe_add", e);
+        }
+    }
+
+    public static MemorySegment fhe_subtract(MemorySegment ctx, MemorySegment a, MemorySegment b) {
+        try {
+            return (MemorySegment) MH_SUBTRACT.invokeExact(ctx, a, b);
+        } catch (Throwable e) {
+            throw new FheException("Failed to call fhe_subtract", e);
         }
     }
 

--- a/src/main/java/com/blindbean/math/BlindMath.java
+++ b/src/main/java/com/blindbean/math/BlindMath.java
@@ -23,6 +23,20 @@ public class BlindMath {
     }
 
     /**
+     * Homomorphically subtracts two ciphertexts, dispatching to the correct backend.
+     */
+    public static Ciphertext subtract(Ciphertext a, Ciphertext b) {
+        if (a.scheme() != b.scheme()) {
+            throw new IllegalArgumentException("Cannot subtract ciphertexts of different schemes: " + a.scheme() + " vs " + b.scheme());
+        }
+        return switch (a.scheme()) {
+            case PAILLIER -> BlindContext.getPaillier().subtract(a, b);
+            case BFV, CKKS -> fheSubtract(a, b);
+            case ELGAMAL -> throw new UnsupportedOperationException("Subtraction not supported for ElGamal");
+        };
+    }
+
+    /**
      * Homomorphically multiplies two ciphertexts.
      * Only supported for FHE schemes (BFV, CKKS).
      */
@@ -45,6 +59,18 @@ public class BlindMath {
              var ctB = FheCiphertextNative.fromBlindCiphertext(ctx, b)) {
 
             var resultHandle = ctx.add(ctA.handle(), ctB.handle());
+            try (var ctResult = new FheCiphertextNative(resultHandle, ctx)) {
+                return ctResult.toBlindCiphertext();
+            }
+        }
+    }
+
+    private static Ciphertext fheSubtract(Ciphertext a, Ciphertext b) {
+        FheContext ctx = BlindContext.getFheContext();
+        try (var ctA = FheCiphertextNative.fromBlindCiphertext(ctx, a);
+             var ctB = FheCiphertextNative.fromBlindCiphertext(ctx, b)) {
+
+            var resultHandle = ctx.subtract(ctA.handle(), ctB.handle());
             try (var ctResult = new FheCiphertextNative(resultHandle, ctx)) {
                 return ctResult.toBlindCiphertext();
             }

--- a/src/main/java/com/blindbean/math/PaillierMath.java
+++ b/src/main/java/com/blindbean/math/PaillierMath.java
@@ -49,4 +49,17 @@ public class PaillierMath {
         BigInteger result = numA.multiply(numB).mod(keyPair.getN2());
         return Ciphertext.fromBytes(result.toByteArray(), Scheme.PAILLIER);
     }
+
+    public Ciphertext subtract(Ciphertext a, Ciphertext b) {
+        if (a.scheme() != Scheme.PAILLIER || b.scheme() != Scheme.PAILLIER) {
+            throw new IllegalArgumentException();
+        }
+        BigInteger numA = new BigInteger(a.getBytes());
+        BigInteger numB = new BigInteger(b.getBytes());
+
+        // Subtraction in Paillier is multiplication by the modular inverse mod n^2
+        BigInteger inverseB = numB.modInverse(keyPair.getN2());
+        BigInteger result = numA.multiply(inverseB).mod(keyPair.getN2());
+        return Ciphertext.fromBytes(result.toByteArray(), Scheme.PAILLIER);
+    }
 }

--- a/src/main/java/com/blindbean/processor/HomomorphicProcessor.java
+++ b/src/main/java/com/blindbean/processor/HomomorphicProcessor.java
@@ -237,9 +237,17 @@ public class HomomorphicProcessor extends AbstractProcessor {
                     emitDecrypt(out, f);
                     out.println();
                     emitAdd(out, f);
+                    out.println();
+                    emitSub(out, f);
+                    out.println();
+                    emitAddPlain(out, f);
+                    out.println();
+                    emitSubPlain(out, f);
                     if (f.scheme() == Scheme.BFV || f.scheme() == Scheme.CKKS) {
                         out.println();
                         emitMultiply(out, f);
+                        out.println();
+                        emitMulPlain(out, f);
                     }
                 }
 
@@ -320,10 +328,95 @@ public class HomomorphicProcessor extends AbstractProcessor {
         out.println("    }");
     }
 
+    private void emitSub(PrintWriter out, FieldModel f) {
+        out.println("    public void sub" + f.capName() + "(Ciphertext other) {");
+        out.println("        Ciphertext diff = BlindMath.subtract(getCiphertext" + f.capName() + "(), other);");
+        out.println("        entity.set" + f.capName() + "(diff.hexData());");
+        out.println("    }");
+    }
+
+    private void emitAddPlain(PrintWriter out, FieldModel f) {
+        switch (f.scheme()) {
+            case PAILLIER -> {
+                out.println("    public void add" + f.capName() + "(BigInteger plain) {");
+                out.println("        Ciphertext ct = BlindContext.getPaillier().encrypt(plain);");
+                out.println("        add" + f.capName() + "(ct);");
+                out.println("    }");
+            }
+            case BFV -> {
+                out.println("    public void add" + f.capName() + "(long plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptLong(plain), ctx)) {");
+                out.println("            add" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            case CKKS -> {
+                out.println("    public void add" + f.capName() + "(double plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptDouble(plain), ctx)) {");
+                out.println("            add" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            default -> throw new IllegalStateException("Unsupported scheme: " + f.scheme());
+        }
+    }
+
+    private void emitSubPlain(PrintWriter out, FieldModel f) {
+        switch (f.scheme()) {
+            case PAILLIER -> {
+                out.println("    public void sub" + f.capName() + "(BigInteger plain) {");
+                out.println("        Ciphertext ct = BlindContext.getPaillier().encrypt(plain);");
+                out.println("        sub" + f.capName() + "(ct);");
+                out.println("    }");
+            }
+            case BFV -> {
+                out.println("    public void sub" + f.capName() + "(long plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptLong(plain), ctx)) {");
+                out.println("            sub" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            case CKKS -> {
+                out.println("    public void sub" + f.capName() + "(double plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptDouble(plain), ctx)) {");
+                out.println("            sub" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            default -> throw new IllegalStateException("Unsupported scheme: " + f.scheme());
+        }
+    }
+
     private void emitMultiply(PrintWriter out, FieldModel f) {
         out.println("    public void mul" + f.capName() + "(Ciphertext other) {");
         out.println("        Ciphertext product = BlindMath.multiply(getCiphertext" + f.capName() + "(), other);");
         out.println("        entity.set" + f.capName() + "(product.hexData());");
         out.println("    }");
+    }
+
+    private void emitMulPlain(PrintWriter out, FieldModel f) {
+        switch (f.scheme()) {
+            case BFV -> {
+                out.println("    public void mul" + f.capName() + "(long plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptLong(plain), ctx)) {");
+                out.println("            mul" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            case CKKS -> {
+                out.println("    public void mul" + f.capName() + "(double plain) {");
+                out.println("        FheContext ctx = BlindContext.getFheContext();");
+                out.println("        try (FheCiphertextNative ct = new FheCiphertextNative(ctx.encryptDouble(plain), ctx)) {");
+                out.println("            mul" + f.capName() + "(ct.toBlindCiphertext());");
+                out.println("        }");
+                out.println("    }");
+            }
+            default -> throw new IllegalStateException("Unsupported scheme: " + f.scheme());
+        }
     }
 }

--- a/src/main/native/blindbean_fhe.cpp
+++ b/src/main/native/blindbean_fhe.cpp
@@ -210,6 +210,22 @@ extern "C" FheCiphertext fhe_add(FheContext handle, FheCiphertext aHandle, FheCi
     }
 }
 
+extern "C" FheCiphertext fhe_subtract(FheContext handle, FheCiphertext aHandle, FheCiphertext bHandle) {
+    try {
+        auto* ctx = static_cast<BlindBeanContext*>(handle);
+        auto* a   = static_cast<seal::Ciphertext*>(aHandle);
+        auto* b   = static_cast<seal::Ciphertext*>(bHandle);
+        if (!ctx || !a || !b) return nullptr;
+
+        auto* result = new seal::Ciphertext();
+        ctx->evaluator->sub(*a, *b, *result);
+        return static_cast<FheCiphertext>(result);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "[SEAL] fhe_subtract error: %s\n", e.what());
+        return nullptr;
+    }
+}
+
 extern "C" FheCiphertext fhe_multiply(FheContext handle, FheCiphertext aHandle, FheCiphertext bHandle) {
     try {
         auto* ctx = static_cast<BlindBeanContext*>(handle);

--- a/src/main/native/blindbean_fhe.h
+++ b/src/main/native/blindbean_fhe.h
@@ -74,6 +74,10 @@ BLINDBEAN_API double fhe_decrypt_double(FheContext ctx, FheCiphertext ct);
  *  Both ciphertexts must belong to the same context. */
 BLINDBEAN_API FheCiphertext fhe_add(FheContext ctx, FheCiphertext a, FheCiphertext b);
 
+/** Homomorphically subtracts two ciphertexts, returning a new ciphertext.
+ *  Both ciphertexts must belong to the same context. */
+BLINDBEAN_API FheCiphertext fhe_subtract(FheContext ctx, FheCiphertext a, FheCiphertext b);
+
 /** Homomorphically multiplies two ciphertexts, returning a new ciphertext.
  *  Automatically relinearizes after multiplication. */
 BLINDBEAN_API FheCiphertext fhe_multiply(FheContext ctx, FheCiphertext a, FheCiphertext b);

--- a/src/test/java/com/blindbean/entity/UserAccountTest.java
+++ b/src/test/java/com/blindbean/entity/UserAccountTest.java
@@ -1,0 +1,47 @@
+package com.blindbean.entity;
+
+import com.blindbean.context.BlindContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserAccountTest {
+
+    @BeforeEach
+    public void setup() {
+        BlindContext.init();
+    }
+
+    @AfterEach
+    public void teardown() {
+        BlindContext.clear();
+    }
+
+    @Test
+    public void testTransparentMath() {
+        // 1. Fetch or Create Entity
+        UserAccount user = new UserAccount(null);
+
+        // 2. Transparently Wrap using the Auto-Generated Helper
+        UserAccountBlindWrapper wrapper = new UserAccountBlindWrapper(user);
+
+        // 3. Encrypt an initial balance natively
+        wrapper.encryptBalance(BigInteger.valueOf(100));
+
+        // 4. Add more to the balance directly via plaintext wrapper!
+        wrapper.addBalance(BigInteger.valueOf(500));
+        
+        // 5. Subtract some from the balance directly!
+        wrapper.subBalance(BigInteger.valueOf(100));
+
+        // 6. Decrypt and verify
+        BigInteger result = wrapper.decryptBalance();
+
+        // 100 + 500 - 100 = 500
+        assertEquals(BigInteger.valueOf(500), result);
+    }
+}

--- a/src/test/java/com/blindbean/processor/HomomorphicProcessorTest.java
+++ b/src/test/java/com/blindbean/processor/HomomorphicProcessorTest.java
@@ -125,7 +125,10 @@ public class HomomorphicProcessorTest {
         assertTrue(wrapperSrc.contains("getCiphertextBalance"), "Missing getCiphertextBalance");
         assertTrue(wrapperSrc.contains("encryptBalance"),       "Missing encryptBalance");
         assertTrue(wrapperSrc.contains("decryptBalance"),       "Missing decryptBalance");
-        assertTrue(wrapperSrc.contains("addBalance"),           "Missing addBalance");
+        assertTrue(wrapperSrc.contains("addBalance(Ciphertext other)"), "Missing addBalance");
+        assertTrue(wrapperSrc.contains("subBalance(Ciphertext other)"), "Missing subBalance");
+        assertTrue(wrapperSrc.contains("addBalance(BigInteger plain)"), "Missing addBalance plain");
+        assertTrue(wrapperSrc.contains("subBalance(BigInteger plain)"), "Missing subBalance plain");
         assertFalse(wrapperSrc.contains("mulBalance"),          "PAILLIER must NOT have mulBalance");
     }
 
@@ -170,8 +173,12 @@ public class HomomorphicProcessorTest {
         assertTrue(wrapperSrc.contains("getCiphertextCounter"), "Missing getCiphertextCounter");
         assertTrue(wrapperSrc.contains("encryptCounter"),       "Missing encryptCounter");
         assertTrue(wrapperSrc.contains("decryptCounter"),       "Missing decryptCounter");
-        assertTrue(wrapperSrc.contains("addCounter"),           "Missing addCounter");
-        assertTrue(wrapperSrc.contains("mulCounter"),           "BFV must have mulCounter");
+        assertTrue(wrapperSrc.contains("addCounter(Ciphertext other)"), "Missing addCounter");
+        assertTrue(wrapperSrc.contains("subCounter(Ciphertext other)"), "Missing subCounter");
+        assertTrue(wrapperSrc.contains("mulCounter(Ciphertext other)"), "Missing mulCounter");
+        assertTrue(wrapperSrc.contains("addCounter(long plain)"), "Missing addCounter plain");
+        assertTrue(wrapperSrc.contains("subCounter(long plain)"), "Missing subCounter plain");
+        assertTrue(wrapperSrc.contains("mulCounter(long plain)"), "Missing mulCounter plain");
     }
 
     // ── Negative tests ────────────────────────────────────────────────────


### PR DESCRIPTION
- Add fhe_subtract in SEAL C++ bridge and map to Java FFM
- Add subtract implementation to PaillierMath
- Extend HomomorphicProcessor to auto-generate math overloads for primitives (BigInteger, long, double)
- Add UserAccountTest integration test
- Update HomomorphicProcessorTest to assert generated wrapper signatures